### PR TITLE
Fixed google sign in

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -29,8 +29,8 @@ export class AuthService {
   }
 
   get user$() {
-    // need to allow facebook since email will always be unverified
-    return this.afAuth.authState.pipe(map(user => user?.emailVerified || user?.photoURL.includes('facebook') ? user : null))
+    // allows all users because unverified users are immediately logged out
+    return this.afAuth.authState
   }
 
   async signInGoogle(): Promise<UserCredential> {


### PR DESCRIPTION
The user observable returned null for an unverified account, and made an exception for facebook and not for google.